### PR TITLE
Remove type requirement from CircularArrayBuffer.

### DIFF
--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -168,7 +168,7 @@ function RLBase.update!(cb::CircularArrayBuffer{T,N}, data::AbstractArray{T}) wh
     cb
 end
 
-function RLBase.update!(cb::CircularArrayBuffer{T,1}, data::Number) where {T}
+function RLBase.update!(cb::CircularArrayBuffer{T,1}, data) where {T}
     cb.buffer[_buffer_frame(cb, cb.length)] = data
     cb
 end


### PR DESCRIPTION
This allows `NonInteractiveEnv`, which only allows `Nothing` actions, to work with `CircularArrayBuffer`.