### PR TITLE
minor bugfix with CircularCompactSARTSATrajectory

### DIFF
--- a/src/components/trajectories/circular_compact_PSARTSA_buffer.jl
+++ b/src/components/trajectories/circular_compact_PSARTSA_buffer.jl
@@ -49,13 +49,13 @@ RLBase.get_trace(t::CircularCompactPSARTSATrajectory, s::Symbol) =
 
 function Base.getindex(b::CircularCompactPSARTSATrajectory, i::Int)
     (
-        priority = select_last_dim(b.priority, i),
         state = select_last_dim(b.trajectory[:state], i),
         action = select_last_dim(b.trajectory[:action], i),
         reward = select_last_dim(b.trajectory[:reward], i),
         terminal = select_last_dim(b.trajectory[:terminal], i),
         next_state = select_last_dim(b.trajectory[:state], i + 1),
         next_action = select_last_dim(b.trajectory[:action], i + 1),
+        priority = select_last_dim(b.priority, i),
     )
 end
 
@@ -82,5 +82,5 @@ function Base.pop!(t::CircularCompactPSARTSATrajectory, s::Symbol)
 end
 
 function Base.pop!(t::CircularCompactPSARTSATrajectory)
-    (priority = pop!(t.priority), pop!(t.trajectory)...)
+    (pop!(t.trajectory)..., priority = pop!(t.priority))
 end

--- a/src/components/trajectories/circular_compact_SARTSA_buffer.jl
+++ b/src/components/trajectories/circular_compact_SARTSA_buffer.jl
@@ -36,20 +36,16 @@ function CircularCompactSARTSATrajectory(;
     terminal_size = (),
 )
     capacity > 0 || throw(ArgumentError("capacity must > 0"))
+    reward = CircularArrayBuffer{reward_type}(reward_size..., capacity)
+    terminal = CircularArrayBuffer{terminal_type}(terminal_size..., capacity)
+    state = CircularArrayBuffer{state_type}(state_size..., capacity + 1)
+    action = CircularArrayBuffer{action_type}(action_size..., capacity + 1)
+    ts = NamedTuple{RTSA}((reward, terminal, state, action))
+
     CircularCompactSARTSATrajectory{
-        Tuple{state_type,action_type,reward_type,terminal_type,state_type,action_type},
-        Tuple{
-            CircularArrayBuffer{reward_type,length(reward_size) + 1},
-            CircularArrayBuffer{terminal_type,length(terminal_size) + 1},
-            CircularArrayBuffer{state_type,length(state_size) + 1},
-            CircularArrayBuffer{action_type,length(action_size) + 1},
-        },
-    }((
-        reward = CircularArrayBuffer{reward_type}(reward_size..., capacity),
-        terminal = CircularArrayBuffer{terminal_type}(terminal_size..., capacity),
-        state = CircularArrayBuffer{state_type}(state_size..., capacity + 1),
-        action = CircularArrayBuffer{action_type}(action_size..., capacity + 1),
-    ))
+        Tuple{frame_type(state), frame_type(action), map(frame_type, ts)...},
+        typeof(ts).parameters[2]
+    }(ts)
 end
 
 isfull(t::CircularCompactSARTSATrajectory) = isfull(t[:action])

--- a/src/utils/base.jl
+++ b/src/utils/base.jl
@@ -1,4 +1,6 @@
-export select_last_dim,
+export nframes,
+    frame_type,
+    select_last_dim,
     select_last_frame,
     consecutive_view,
     find_all_max,
@@ -15,6 +17,10 @@ export select_last_dim,
     unflatten_batch
 
 using StatsBase
+
+nframes(a::AbstractArray{T,N}) where {T,N} = size(a, N)
+frame_type(::Array{T, N}) where {T, N} = Array{T, N-1}
+frame_type(::Vector{T}) where T = T
 
 select_last_dim(xs::AbstractArray{T,N}, inds) where {T,N} =
     @views xs[ntuple(_ -> (:), N - 1)..., inds]

--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -1,4 +1,4 @@
-export CircularArrayBuffer, capacity, isfull, nframes
+export CircularArrayBuffer, capacity, isfull
 
 """
     CircularArrayBuffer{T}(d::Integer...) -> CircularArrayBuffer{T, N}
@@ -127,7 +127,6 @@ Base.getindex(cb::CircularArrayBuffer{T,N}, i::Int) where {T,N} =
 Base.setindex!(cb::CircularArrayBuffer{T,N}, v, i::Int) where {T,N} =
     setindex!(cb.buffer, v, _buffer_index(cb, i))
 capacity(cb::CircularArrayBuffer{T,N}) where {T,N} = size(cb.buffer, N)
-nframes(cb::CircularArrayBuffer) = cb.length
 isfull(cb::CircularArrayBuffer) = cb.length == capacity(cb)
 Base.isempty(cb::CircularArrayBuffer) = cb.length == 0
 
@@ -199,4 +198,5 @@ function Base.pop!(cb::CircularArrayBuffer)
     res
 end
 
-nframes(a::AbstractArray{T,N}) where {T,N} = size(a, N)
+frame_type(::CircularArrayBuffer{T, N}) where {T, N} = Array{T, N-1}
+frame_type(::CircularArrayBuffer{T, 1}) where {T} = T


### PR DESCRIPTION
The `types` parameter of CircularCompactSARTSATrajectory was wrong.