### PR TITLE
remove the default implementation

### DIFF
--- a/src/components/learners/learners.jl
+++ b/src/components/learners/learners.jl
@@ -12,18 +12,6 @@ abstract type AbstractLearner end
 function (learner::AbstractLearner)(obs) end
 
 """
-    update!(learner::AbstractLearner, experience)
-
-Typical `experience` is [`AbstractTrajectory`](@ref).
-"""
-function RLBase.update!(learner::AbstractLearner, t::AbstractTrajectory)
-    experience = extract_experience(t, learner)
-    isnothing(experience) || update!(learner, experience)
-end
-
-function extract_experience end
-
-"""
     get_priority(p::AbstractLearner, experience)
 """
 function RLBase.get_priority(p::AbstractLearner, experience) end


### PR DESCRIPTION
closes #63 

Actually this PR doesn't resolve #63, but I happened to find a performance bug when implementing this feature in https://github.com/JuliaReinforcementLearning/ReinforcementLearningZoo.jl/pull/21

According to my local test. The speed can be increased by ~ 20% when if multi-threading is enabled.