### PR TITLE
Fix some corner cases when sampling a SumTree

### DIFF
--- a/src/utils/sum_tree.jl
+++ b/src/utils/sum_tree.jl
@@ -124,7 +124,6 @@ function Base.empty!(t::SumTree)
     t
 end
 
-"!!! this is unsafe, always check the `real_ind`, or you may get bound error in some extreme cases."
 function Base.get(t::SumTree, v)
     parent_ind = 1
     leaf_ind = parent_ind
@@ -142,6 +141,9 @@ function Base.get(t::SumTree, v)
                 parent_ind = right_child_ind
             end
         end
+    end
+    if leaf_ind <= t.nparents
+        leaf_ind += t.capacity
     end
     p = t.tree[leaf_ind]
     ind = leaf_ind - t.nparents

--- a/src/utils/sum_tree.jl
+++ b/src/utils/sum_tree.jl
@@ -154,10 +154,11 @@ end
 sample(rng::AbstractRNG, t::SumTree{T}) where {T} = get(t, rand(rng, T) * t.tree[1])
 sample(t::SumTree) = sample(Random.GLOBAL_RNG, t)
 
-function sample(rng::AbstractRNG, t::SumTree, n::Int)
+function sample(rng::AbstractRNG, t::SumTree{T}, n::Int) where {T}
     inds, priorities = Vector{Int}(undef, n), Vector{Float64}(undef, n)
     for i in 1:n
-        ind, p = sample(rng, t)
+        v = (i-1+rand(rng,T)) / n
+        ind, p = get(t, v * t.tree[1])
         inds[i] = ind
         priorities[i] = p
     end


### PR DESCRIPTION
Though the fix here seems to be trivial. But it fixes some big problems in prioritized experience buffer.

Before this, the loss of rainbow with atari pong:

![image](https://user-images.githubusercontent.com/5612003/85551129-4509ce00-b654-11ea-9080-7369fca75b99.png)

After this fix:

![image](https://user-images.githubusercontent.com/5612003/85551172-518e2680-b654-11ea-9cc6-1c16277912be.png)

The reason is that, in some cases, `get(t::SumTree, v)` might return `ind, p` where `p=0.0`. And it makes the rescaled weights decreased to nearly zero.