### PR TITLE
updated send_to_device for ElasticArray.

### DIFF
--- a/src/utils/device.jl
+++ b/src/utils/device.jl
@@ -17,7 +17,12 @@ send_to_device(
     ::Val{:gpu},
     x::Union{
         SubArray{<:Any,<:Any,<:Union{CircularArrayBuffer,ElasticArray}},
-        Base.ReshapedArray{<:Any,<:Any,<:SubArray{<:Any,<:Any,<:CircularArrayBuffer}},
+        Base.ReshapedArray{
+            <:Any,
+            <:Any,
+            <:SubArray{<:Any,<:Any,<:Union{CircularArrayBuffer,ElasticArray}},
+        },
+        Base.ReshapedArray{<:Any,<:Any,<:Union{CircularArrayBuffer,ElasticArray}},
         SubArray{
             <:Any,
             <:Any,


### PR DESCRIPTION
this is for 
```
ElasticArray() |> x -> Flux.unsqueeze(x, 1)
```
which type is `Base.ReshapedArray{<:Any,<:Any,<:ElasticArray}`