### PR TITLE
Minor edits to CircularArrayBuffer

### DIFF
--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -35,9 +35,6 @@ julia> b
 julia> length(b)
 4
 
-julia> nframes(cb::CircularArrayBuffer) = cb.length
-nframes (generic function with 1 method)
-
 julia> nframes(b)
 1
 

--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -5,8 +5,8 @@ using ReinforcementLearningBase
 """
     CircularArrayBuffer{T}(d::Integer...) -> CircularArrayBuffer{T, N}
 
-`CircularArrayBuffer` uses a `N`-dimention `Array` of size `d` to serve as a buffer for
-`N-1`-dimention `Array`s with the same size.
+`CircularArrayBuffer` uses a `N`-dimension `Array` of size `d` to serve as a buffer for
+`N-1`-dimension `Array`s with the same size.
 
 # Examples
 

--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -137,11 +137,7 @@ end
 @inline function _buffer_frame(cb::CircularArrayBuffer, i::Int)
     n = capacity(cb)
     idx = cb.first + i - 1
-    if idx > n
-        idx - n
-    else
-        idx
-    end
+    mod1(idx, n)
 end
 
 _buffer_frame(cb::CircularArrayBuffer, I::Vector{Int}) = map(i -> _buffer_frame(cb, i), I)

--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -120,7 +120,7 @@ end
 Base.IndexStyle(::CircularArrayBuffer) = IndexLinear()
 Base.size(cb::CircularArrayBuffer{<:Any,N}, i::Integer) where {N} =
     i == N ? cb.nframes : size(cb.buffer, i)
-Base.size(cb::CircularArrayBuffer{<:Any,N}) where {N} = ntuple(M -> size(cb, M), N)
+Base.size(cb::CircularArrayBuffer{<:Any,N}) where {N} = ntuple(i -> size(cb, i), N)
 Base.getindex(cb::CircularArrayBuffer{T,N}, i::Int) where {T,N} =
     getindex(cb.buffer, _buffer_index(cb, i))
 Base.setindex!(cb::CircularArrayBuffer{T,N}, v, i::Int) where {T,N} =

--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -151,7 +151,6 @@ end
 _buffer_frame(cb::CircularArrayBuffer, I::Vector{Int}) = map(i -> _buffer_frame(cb, i), I)
 
 function Base.empty!(cb::CircularArrayBuffer)
-    cb.first = 1
     cb.nframes = 0
     cb
 end

--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -157,7 +157,7 @@ function RLBase.update!(cb::CircularArrayBuffer{T,N}, data::AbstractArray) where
     cb
 end
 
-function RLBase.update!(cb::CircularArrayBuffer{T,1}, data) where {T}
+function RLBase.update!(cb::CircularArrayBuffer{T,1}, data::T) where {T}
     cb.buffer[_buffer_frame(cb, cb.nframes)] = data
     cb
 end

--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -157,7 +157,7 @@ function RLBase.update!(cb::CircularArrayBuffer{T,N}, data::AbstractArray) where
     cb
 end
 
-function RLBase.update!(cb::CircularArrayBuffer{T,1}, data::T) where {T}
+function RLBase.update!(cb::CircularArrayBuffer{T,1}, data) where {T}
     cb.buffer[_buffer_frame(cb, cb.nframes)] = data
     cb
 end

--- a/src/utils/circular_array_buffer.jl
+++ b/src/utils/circular_array_buffer.jl
@@ -131,11 +131,7 @@ Base.isempty(cb::CircularArrayBuffer) = cb.nframes == 0
 
 @inline function _buffer_index(cb::CircularArrayBuffer, i::Int)
     ind = (cb.first - 1) * cb.step_size + i
-    if ind > length(cb.buffer)
-        ind - length(cb.buffer)
-    else
-        ind
-    end
+    mod1(ind, length(cb.buffer))
 end
 
 @inline function _buffer_frame(cb::CircularArrayBuffer, i::Int)

--- a/test/utils/circular_array_buffer.jl
+++ b/test/utils/circular_array_buffer.jl
@@ -1,5 +1,6 @@
 @testset "CircularArrayBuffer" begin
     A = ones(2, 2)
+    C = ones(Float32, 2, 2)
     @testset "1D Int" begin
         b = CircularArrayBuffer{Int}(3)
 
@@ -131,5 +132,51 @@
         @test b[:, :, end] == 5 * A
 
         @test b == reshape([c for x in 3:5 for c in x * A], 2, 2, 3)
+
+        push!(b, 6 * ones(Float32, 2, 2))
+        push!(b, 7 * ones(Int, 2, 2))
+        @test b == reshape([c for x in 5:7 for c in x * A], 2, 2, 3)
+    end
+
+    @testset "2D Float32" begin
+        b = CircularArrayBuffer{Float32}(2, 2, 3)
+
+        @test eltype(b) == Float32
+        @test capacity(b) == 3
+        @test isfull(b) == false
+        @test length(b) == 0
+        @test nframes(b) == 0
+        @test size(b) == (2, 2, 0)
+
+        for x in 1:3
+            push!(b, x * C)
+        end
+
+        @test capacity(b) == 3
+        @test isfull(b) == true
+        @test nframes(b) == 3
+        @test length(b) == 2 * 2 * 3
+        @test size(b) == (2, 2, 3)
+        for i in 1:3
+            @test b[:, :, i] == i * C
+        end
+        @test b[:, :, end] == 3 * C
+
+        for x in 4:5
+            push!(b, x * ones(Float32, 2, 2))  # collection is also OK
+        end
+
+        @test capacity(b) == 3
+        @test length(b) == 2 * 2 * 3
+        @test nframes(b) == 3
+        @test size(b) == (2, 2, 3)
+        @test b[:, :, 1] == 3 * C
+        @test b[:, :, end] == 5 * C
+
+        @test b == reshape([c for x in 3:5 for c in x * C], 2, 2, 3)
+
+        push!(b, 6 * ones(Float64, 2, 2))
+        push!(b, 7 * ones(Int, 2, 2))
+        @test b == reshape([c for x in 5:7 for c in x * C], 2, 2, 3)
     end
 end


### PR DESCRIPTION
Adding some minor changes to the [circular_array_buffer.jl](https://github.com/JuliaReinforcementLearning/ReinforcementLearningCore.jl/blob/master/src/utils/circular_array_buffer.jl) file in order to make things a little more intuitive.
1. Removing re-definition of the `nframes` method in the example ([this](https://github.com/JuliaReinforcementLearning/ReinforcementLearningCore.jl/blob/8cb45fa983e43517bd22adc38e1a8a28c2c3e7b7/src/utils/base.jl#L20) method directly works).
2. Converting the field name `length` to `nframes`. The name `length` is already used as a method name with a different interpretation.
3. Remove unnecessary the reset `cb.first to 1` since it is not required for a circular array. Elements will get overwritten accordingly.
4. Take modulus of indices to make them truly circular and support numbers beyond the normal range.
5. Annotate `data::T` [here](https://github.com/JuliaReinforcementLearning/ReinforcementLearningCore.jl/blob/8cb45fa983e43517bd22adc38e1a8a28c2c3e7b7/src/utils/circular_array_buffer.jl#L172).