### PR TITLE
updated github workflows.

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,2 @@
+verbose         = true
+always_for_in   = true

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,18 +1,11 @@
 name: CompatHelper
-
 on:
   schedule:
     - cron: '00 00 * * *'
   workflow_dispatch:
-
 jobs:
   CompatHelper:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.2.0]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -1,27 +1,17 @@
 name: format-pr
-
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.3.0]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.julia-version }}
-
       - uses: actions/checkout@v2
       - name: Install JuliaFormatter and format
         run: |
           julia  -e 'import Pkg; Pkg.add("JuliaFormatter")'
-          julia  -e 'using JuliaFormatter; format(".";verbose=true, always_for_in=true)'
-          
+          julia  -e 'using JuliaFormatter; format(".")'
+
       # https://github.com/marketplace/actions/create-pull-request
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2


### PR DESCRIPTION
fixes https://github.com/JuliaReinforcementLearning/ReinforcementLearning.jl/issues/165

1. copied CompatHelper from https://github.com/JuliaRegistries/CompatHelper.jl#11-create-the-workflow-file-required .
2. removed formatter options from format_pr.yml.
3. added julia formatter config file.

Now run `format(".")` locally will get the same result as in github.

BTW, I saw CompatHelper removed `setup-julia`action. so I did the same thing in `format-pr`
https://github.com/JuliaRegistries/CompatHelper.jl/commit/6b35a7b98d21f2349b8c91b171c57c3c38a12464#diff-5aa37a40d0f0d9f8a355bf14071e63cd81627fe63730c12992c1d63e2977afea
But I'm not sure if this can work.

https://github.com/julia-actions/julia-format/blob/master/workflows/format_pr.yml
was not updated for a long time. I guess it's outdated.

The docker version of julia formatter was deprecated, it does not exist anymore.