### PR TITLE
updated format_pr.

### DIFF
--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -13,15 +13,18 @@ jobs:
           julia  -e 'using JuliaFormatter; format(".")'
 
       # https://github.com/marketplace/actions/create-pull-request
+      # https://github.com/peter-evans/create-pull-request#reference-example
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Format .jl files
           title: 'Automatic JuliaFormatter.jl run'
           branch: auto-juliaformatter-pr
+          delete-branch: true
           labels: formatting, automated pr, no changelog
       - name: Check outputs
         run: |
-          echo 'Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}'
-          echo 'Pull Request Number - ${{ steps.cpr.outputs.pr_number }}'
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
All the format-pr workflows have failed.
log: 
https://github.com/JuliaReinforcementLearning/ReinforcementLearningCore.jl/runs/1564204245?check_suite_focus=true

It seems `peter-evans/create-pull-request@v2` has been deprecated. So update it again. ref: https://github.com/peter-evans/create-pull-request#reference-example
