### PR TITLE
in _run, add hook for PRE_EXPERIMENT_STAGE &  Post...

### DIFF
--- a/src/core/run.jl
+++ b/src/core/run.jl
@@ -15,6 +15,7 @@ function check(policy, env) end
 
 function _run(policy::AbstractPolicy, env::AbstractEnv, stop_condition, hook::AbstractHook)
 
+    hook(PRE_EXPERIMENT_STAGE, policy, env)
     is_stop = false
     while !is_stop
         reset!(env)
@@ -43,5 +44,6 @@ function _run(policy::AbstractPolicy, env::AbstractEnv, stop_condition, hook::Ab
             hook(POST_EPISODE_STAGE, policy, env)
         end
     end
+    hook(POST_EXPERIMENT_STAGE, policy, env)
     hook
 end


### PR DESCRIPTION
We have defined `PRE_EXPERIMENT_STAGE` & `POST...`
But this is not used in `run`.

this is very useful. I can use `POST_EXPERIMENT_STAGE` hook to save the training history.
