### PR TITLE
Add support of length and fetch! for CircularArraySLARTTrajectory

### DIFF
--- a/src/policies/agents/trajectories/trajectory.jl
+++ b/src/policies/agents/trajectories/trajectory.jl
@@ -254,6 +254,7 @@ CircularArrayPSARTTrajectory(; capacity, kwargs...) = PrioritizedTrajectory(
 function Base.length(
     t::Union{
         CircularArraySARTTrajectory,
+        CircularArraySLARTTrajectory,
         CircularVectorSARTSATrajectory,
         ElasticSARTTrajectory,
     },

--- a/src/policies/agents/trajectories/trajectory_extension.jl
+++ b/src/policies/agents/trajectories/trajectory_extension.jl
@@ -140,7 +140,7 @@ end
 
 function fetch!(
     sampler::NStepBatchSampler{traces},
-    traj::CircularArraySARTTrajectory,
+    traj::Union{CircularArraySARTTrajectory, CircularArraySLARTTrajectory},
     inds::Vector{Int},
 ) where {traces}
     γ, n, bz, sz = sampler.γ, sampler.n, sampler.batch_size, sampler.stack_size

--- a/test/components/trajectories.jl
+++ b/test/components/trajectories.jl
@@ -51,7 +51,7 @@
     @testset "CircularArraySLARTTrajectory" begin
         t = CircularArraySLARTTrajectory(
             capacity = 3,
-            state = Matrix{Float32} => (2,2),
+            state = Vector{Int} => (4,),
             legal_actions_mask = Vector{Bool} => (4, ),
         )
         
@@ -61,7 +61,7 @@
         @test length(t) == 0
         push!(t; state = ones(Int, 4), action = 1, legal_actions_mask = trues(4))
         @test length(t) == 0
-        push!(t; reward = 1.0f0, terminal = false,)
+        push!(t; reward = 1.0f0, terminal = false)
         @test length(t) == 1
     end
 

--- a/test/components/trajectories.jl
+++ b/test/components/trajectories.jl
@@ -57,6 +57,12 @@
         
         # test instance type is same as type
         @test isa(t, CircularArraySLARTTrajectory)
+
+        @test length(t) == 0
+        push!(t; state = ones(Int, 4), action = 1, legal_actions_mask = trues(4))
+        @test length(t) == 0
+        push!(t; reward = 1.0f0, terminal = false,)
+        @test length(t) == 1
     end
 
     @testset "ReservoirTrajectory" begin


### PR DESCRIPTION
I did that because I need this support in my use case, but I can feel that, especially for `fetch!`, I did not do it the right way.

Would there be any better way to do this?