### PR TITLE
Make DoEveryNStep conform to documentation

### DIFF
--- a/src/core/hooks.jl
+++ b/src/core/hooks.jl
@@ -236,16 +236,16 @@ end
 """
     DoEveryNStep(f; n=1, t=0)
 
-Execute `f(agent, env)` every `n` step.
+Execute `f(t, agent, env)` every `n` step.
 `t` is a counter of steps.
 """
-Base.@kwdef mutable struct DoEveryNStep{F} <: AbstractHook
+mutable struct DoEveryNStep{F} <: AbstractHook
     f::F
-    n::Int = 1
-    t::Int = 0
+    n::Int
+    t::Int
 end
 
-DoEveryNStep(f, n = 1, t = 0) = DoEveryNStep(f, n, t)
+DoEveryNStep(f; n = 1, t = 0) = DoEveryNStep(f, n, t)
 
 function (hook::DoEveryNStep)(::PostActStage, agent, env)
     hook.t += 1


### PR DESCRIPTION
I noticed that the hook `DoEveryNStep` did not implement the constructors that the documentation claimed. I think the documentation felt more reasonable than the implementation so this PR will update it that way, though this is just my opinion.

Specifically it claimed that it was `DoEveryNStep(f; n=1, t=0)` which means we should be able to do
```julia
DoEveryNStep(n=3) do t, env, action
...
end
```
but this did not currently work.

I also updated the documentation to include the `t` in the description of the executed method.

I removed the `Base.@kwargs` since this was not documented and in my opinion not really needed since the existing constructor covers all interesting cases. This will be a breaking change and this change could easily be skipped while still implementing the others.